### PR TITLE
Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     "require-dev": {
         "laravel/pint": "^1.24",
         "nunomaduro/collision": "^8.0",
-        "nunomaduro/larastan": "^3.5",
+        "nunomaduro/larastan": "^3.5|^3.9.3",
         "orchestra/testbench": "^10.4|^11.0",
-        "pestphp/pest": "^3.8",
-        "pestphp/pest-plugin-laravel": "^3.2",
+        "pestphp/pest": "^3.8|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.2|^4.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5|^12.3",
         "rregeer/phpunit-coverage-check": "^0.3",
         "spatie/laravel-ray": "^1.40"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.92.4",
-        "illuminate/contracts": "^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.24",
         "nunomaduro/collision": "^8.0",
         "nunomaduro/larastan": "^3.5",
-        "orchestra/testbench": "^10.4",
+        "orchestra/testbench": "^10.4|^11.0",
         "pestphp/pest": "^3.8",
         "pestphp/pest-plugin-laravel": "^3.2",
         "phpstan/extension-installer": "^1.4",


### PR DESCRIPTION
## Summary
- Allow `illuminate/contracts: ^13.0` in `composer.json`
- Allow `orchestra/testbench: ^11.0` for dev
- Add `laravel: 13.*` (with testbench `11.*`) to the CI matrix, excluding PHP 8.2 since Laravel 13 requires PHP 8.3+

## Test plan
- [ ] CI matrix passes on L11/L12/L13 across PHP 8.2–8.4 (excluding L13 + PHP 8.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)